### PR TITLE
feat: added showLabels setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Failing to do so may result in a component whose size that will keep increasing.
 
    Duration for out animation in milliseconds 
 
+- `show-labels` ***Boolean*** (*optional*) `default: false` 
+
+   Show labels for arcs
+
 #### events 
 
 - `mouseOverNode` 

--- a/example/App.vue
+++ b/example/App.vue
@@ -52,6 +52,13 @@
                 </div>
               </div>
 
+              <div class="form-group">
+                <label for="showLabels">Show labels</label>
+                <div>
+                    <input id="showLabels" type="checkbox" v-model="showLabels">
+                </div>
+              </div>
+
             </div>
           </div>
         </div>
@@ -60,7 +67,7 @@
         <div class="card control-left">
           <div class="card-header">Sunburst</div>
           <div class="card-body father">
-            <sunburst class="sunburst" :data="data" :minAngleDisplayed="minAngleDisplayed" :colorScheme="colorScheme" :colorScale="colorScale" :inAnimationDuration="inAnimationDuration" :outAnimationDuration="outAnimationDuration">
+            <sunburst class="sunburst" :data="data" :minAngleDisplayed="minAngleDisplayed" :colorScheme="colorScheme" :colorScale="colorScale" :inAnimationDuration="inAnimationDuration" :outAnimationDuration="outAnimationDuration" :showLabels="showLabels">
 
               <breadcrumbTrail slot="legend" slot-scope="{ nodes, colorGetter, width }" :current="nodes.mouseOver" :root="nodes.root" :colorGetter="colorGetter" :from="nodes.zoomed" :width="width" />
 
@@ -107,6 +114,7 @@ export default {
       outAnimationDuration: 1000,
       overrideColorScale: false,
       custoColorScale: scaleOrdinal(["#e39b89", "#31ea74", "#3c7227", "#9dad1f"])
+      showLabels: true
     };
   },
   computed:{

--- a/example/App.vue
+++ b/example/App.vue
@@ -113,8 +113,8 @@ export default {
       inAnimationDuration: 100,
       outAnimationDuration: 1000,
       overrideColorScale: false,
-      custoColorScale: scaleOrdinal(["#e39b89", "#31ea74", "#3c7227", "#9dad1f"])
-      showLabels: true
+      custoColorScale: scaleOrdinal(["#e39b89", "#31ea74", "#3c7227", "#9dad1f"]),
+      showLabels: false
     };
   },
   computed:{

--- a/example/App.vue
+++ b/example/App.vue
@@ -7,6 +7,13 @@
           <div class="card-body">
             <div class="form-horizontal">
 
+              <div class="form-group custo-checkbox">
+                <label for="showLabels">Show labels</label>
+                <div>
+                    <input id="showLabels" type="checkbox" v-model="showLabels">
+                </div>
+              </div>
+
                <div class="form-group custo-checkbox">
                 <label for="colorScheme" class="control-label">Use custom color scheme</label>
                 <div >
@@ -49,13 +56,6 @@
                 </div>
                 <div>
                   <p>{{outAnimationDuration}} ms</p>
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label for="showLabels">Show labels</label>
-                <div>
-                    <input id="showLabels" type="checkbox" v-model="showLabels">
                 </div>
               </div>
 
@@ -113,12 +113,17 @@ export default {
       inAnimationDuration: 100,
       outAnimationDuration: 1000,
       overrideColorScale: false,
-      custoColorScale: scaleOrdinal(["#e39b89", "#31ea74", "#3c7227", "#9dad1f"]),
+      custoColorScale: scaleOrdinal([
+        "#e39b89",
+        "#31ea74",
+        "#3c7227",
+        "#9dad1f"
+      ]),
       showLabels: false
     };
   },
-  computed:{
-    colorScale(){
+  computed: {
+    colorScale() {
       return this.overrideColorScale ? this.custoColorScale : null;
     }
   },

--- a/src/components/sunburst.vue
+++ b/src/components/sunburst.vue
@@ -147,6 +147,15 @@ export default {
       type: Number,
       required: false,
       default: 1000
+    },
+    /**
+     *  Show labels for arcs
+     */
+    // TODO: Maybe this would be better as a slot?
+    showLabels: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
 
@@ -233,6 +242,8 @@ export default {
         return;
       }
 
+      const _this = this;
+
       this.root = hierarchy(data)
         .sum(d => d.size)
         .sort((a, b) => b.value - a.value);
@@ -249,9 +260,9 @@ export default {
       const click = this.click.bind(this);
       const { arcSunburst } = this;
 
-      pathes
-        .enter()
-        .append("path")
+      const g = pathes.enter().append("g");
+
+      g.append("path")
         .style("opacity", 1)
         .on("mouseover", mouseOver)
         .on("click", click)
@@ -265,6 +276,21 @@ export default {
         .attrTween("d", function(d, index) {
           return arc2Tween.call(this, arcSunburst, d, index);
         });
+
+      if (this.showLabels) {
+        g.append("text")
+          .attr("transform", function(d) {
+            return "rotate(" + _this.computeTextRotation(d) + ")";
+          })
+          .attr("x", function(d) {
+            return _this.scaleY(d.y0);
+          })
+          .attr("dx", "6") // margin
+          .attr("dy", ".35em") // vertical-align
+          .text(function(d) {
+            return d.data.name;
+          });
+      }
 
       pathes.exit().remove();
 
@@ -389,6 +415,15 @@ export default {
         .transition()
         .duration(this.outAnimationDuration)
         .style("opacity", 1);
+    },
+
+    /**
+     * @private
+     */
+    computeTextRotation: function(d) {
+      const dx = d.x1 - d.x0;
+      let rot = ((this.scaleX(d.x0 + dx / 2) - Math.PI / 2) / Math.PI) * 180;
+      return rot;
     }
   },
 

--- a/src/components/sunburst.vue
+++ b/src/components/sunburst.vue
@@ -242,8 +242,6 @@ export default {
         return;
       }
 
-      const _this = this;
-
       this.root = hierarchy(data)
         .sum(d => d.size)
         .sort((a, b) => b.value - a.value);
@@ -281,17 +279,11 @@ export default {
 
       if (this.showLabels) {
         g.append("text")
-          .attr("transform", function(d) {
-            return "rotate(" + _this.computeTextRotation(d) + ")";
-          })
-          .attr("x", function(d) {
-            return _this.scaleY(d.y0);
-          })
+          .attr("transform", (d) => `rotate(${this.computeTextRotation(d)})`)
+          .attr("x", (d) => this.scaleY(d.y0))
           .attr("dx", "6") // margin
           .attr("dy", ".35em") // vertical-align
-          .text(function(d) {
-            return d.data.name;
-          });
+          .text((d) => d.data.name);
       }
 
       pathes.exit().remove();

--- a/src/components/sunburst.vue
+++ b/src/components/sunburst.vue
@@ -237,7 +237,7 @@ export default {
      */
     onData(data) {
       if (!data) {
-        this.vis.selectAll("path").remove();
+        this.vis.selectAll("g").remove();
         Object.keys(this.graphNodes).forEach(k => (this.graphNodes[k] = null));
         return;
       }
@@ -260,16 +260,18 @@ export default {
       const click = this.click.bind(this);
       const { arcSunburst } = this;
 
-      const g = pathes.enter().append("g");
+      const g = pathes
+        .enter()
+        .append("g")
+        .on("mouseover", mouseOver)
+        .on("click", click)
+        .merge(pathes);
 
       g.append("path")
         .style("opacity", 1)
-        .on("mouseover", mouseOver)
-        .on("click", click)
         .each(function(d) {
           copyCurrentValues(this, d);
         })
-        .merge(pathes)
         .style("fill", d => colorGetter(d.data))
         .transition("enter")
         .duration(this.inAnimationDuration)
@@ -301,9 +303,7 @@ export default {
      * @private
      */
     getPathes() {
-      return this.vis
-        .selectAll("path")
-        .data(this.nodes, this.arcIdentification);
+      return this.vis.selectAll("g").data(this.nodes, this.arcIdentification);
     },
 
     /**
@@ -420,10 +420,9 @@ export default {
     /**
      * @private
      */
-    computeTextRotation: function(d) {
+    computeTextRotation(d) {
       const dx = d.x1 - d.x0;
-      let rot = ((this.scaleX(d.x0 + dx / 2) - Math.PI / 2) / Math.PI) * 180;
-      return rot;
+      return ((this.scaleX(d.x0 + dx / 2) - Math.PI / 2) / Math.PI) * 180;
     }
   },
 
@@ -466,6 +465,10 @@ export default {
     },
 
     minAngleDisplayed() {
+      this.reDraw();
+    },
+
+    showLabels() {
       this.reDraw();
     }
   }


### PR DESCRIPTION
Fixes #14 

Looked at how it was done in http://bl.ocks.org/metmajer/5480307 for inspiration.

Issues:

 - [x] The showLabels setting doesn't apply when toggled
 - [x] mouseover/click handlers are set on the path, should be set on the group
 - [x] getPathes should probably `selectAll('g')`
 - [x] When showLabels is toggled off there are text elements remaining (I'm not good enough at D3 to understand why)
 - [x] Labels don't disappear/update on click/zoom (might be related to the previous issue)
 - [x] Labels for the left half become upside down
 - [x] Long labels are overflowing (not sure if there's a good way to fix this, fixing it is not a priority for me)