### PR TITLE
sorting options, disable or callback function

### DIFF
--- a/src/components/sunburst.vue
+++ b/src/components/sunburst.vue
@@ -92,6 +92,10 @@ function computeStoreDx(d, context) {
   return dx;
 }
 
+function defaultSort(a, b){
+   return b.value - a.value;
+}
+
 const useNameForColor = d => d.name;
 const miminalRadius = 20;
 
@@ -207,6 +211,22 @@ export default {
       required: false,
       default: 0.3,
       validator: v => v >= 0 && v < 1
+    },
+    /**
+     *  Function used sort level-1 nodes, will be used on the onData function.
+     */
+    sort: {
+      type: Function,
+      required: false,
+      default: defaultSort,
+    },
+    /**
+     *  If true disable sort on the level-1 nodes.
+     */
+    disableSort: {
+      type: Boolean,
+      required: false,
+      default: false,
     }
   },
 
@@ -415,9 +435,8 @@ export default {
       }
 
       if (!onlyRedraw) {
-        this.root = hierarchy(data)
-          .sum(d => d.size)
-          .sort((a, b) => b.value - a.value);
+        this.root = hierarchy(data).sum(d => d.size);
+        if(!this.disableSort) this.root = this.root.sort(this.sort);
 
         this.nodes = partition()(this.root).descendants();
 


### PR DESCRIPTION
Given the circumstances one could need a different order on the sunburst nodes, providing a callback we make sure what order is going to be applied instead of the previous higher to lower sorting. 
Also, a disabled option makes this easier letting the parent decide the sort without sending a callback.